### PR TITLE
Fix duplicate calendar events by quoting video_id

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,7 +70,7 @@ def main():
             try:
                 events_result = calendar.events().list(
                     calendarId=CALENDAR_ID,
-                    privateExtendedProperty=f"youtubeVideoId={video_id}",
+                    privateExtendedProperty=f"youtubeVideoId='{video_id}'",
                     maxResults=1
                 ).execute()
                 if events_result.get('items'):


### PR DESCRIPTION
The script was creating duplicate calendar events because the search for existing events was failing. This was likely due to the `privateExtendedProperty` query not handling video IDs with special characters correctly.

This change fixes the issue by enclosing the `video_id` in single quotes within the `privateExtendedProperty` query. This ensures that the video ID is treated as a single string literal, making the search for existing events more robust and preventing the creation of duplicates.